### PR TITLE
Java - RestTemplate - rethrow original exception when retry limits exceeded

### DIFF
--- a/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
+++ b/modules/openapi-generator/src/main/resources/Java/libraries/resttemplate/ApiClient.mustache
@@ -31,6 +31,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -772,20 +773,29 @@ public class ApiClient{{#jsr310}} extends JavaTimeFormatter{{/jsr310}} {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/echo_api/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -688,20 +689,29 @@ public class ApiClient extends JavaTimeFormatter {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/others/java/resttemplate-useAbstractionForFiles/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -631,20 +632,29 @@ public class ApiClient extends JavaTimeFormatter {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-jakarta/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -680,20 +681,29 @@ public class ApiClient extends JavaTimeFormatter {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger1/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -680,20 +681,29 @@ public class ApiClient extends JavaTimeFormatter {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-swagger2/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -680,20 +681,29 @@ public class ApiClient extends JavaTimeFormatter {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate-withXml/src/main/java/org/openapitools/client/ApiClient.java
@@ -27,6 +27,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -743,20 +744,29 @@ public class ApiClient extends JavaTimeFormatter {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {

--- a/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
+++ b/samples/client/petstore/java/resttemplate/src/main/java/org/openapitools/client/ApiClient.java
@@ -22,6 +22,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -738,20 +739,29 @@ public class ApiClient extends JavaTimeFormatter {
             try {
                 responseEntity = restTemplate.exchange(requestEntity, returnType);
                 break;
-            } catch (HttpServerErrorException ex) {
-                attempts++;
-                if (attempts < maxAttemptsForRetry) {
-                    try {
-                        Thread.sleep(waitTimeMillis);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
+            } catch (HttpServerErrorException | HttpClientErrorException ex) {
+                if (ex instanceof HttpServerErrorException
+                        || ((HttpClientErrorException) ex)
+                        .getStatusCode()
+                        .equals(HttpStatus.TOO_MANY_REQUESTS)) {
+                    attempts++;
+                    if (attempts < maxAttemptsForRetry) {
+                        try {
+                            Thread.sleep(waitTimeMillis);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        throw ex;
                     }
+                } else {
+                    throw ex;
                 }
             }
         }
 
         if (responseEntity == null) {
-            throw new RestClientException("API returned HttpServerErrorException");
+            throw new RestClientException("ResponseEntity is null");
         }
 
         if (responseEntity.getStatusCode().is2xxSuccessful()) {


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

in rest template, when the retry limits exceeded
rethrow the original exception

also add 429 (Too many requests) status code to the retry logic

fix #17478

<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
